### PR TITLE
Modify getUserValues() to always output in the same order regardless of input order

### DIFF
--- a/user-processing.js
+++ b/user-processing.js
@@ -1,1 +1,3 @@
-export const getUserValues = (userObj) => Object.values(userObj).join("|")
+export const getUserValues = (userObj) => {
+    return userObj.id + "|" + userObj.username + "|" + userObj.firstName + "|" + userObj.lastName + "|" + userObj.studentId;
+}

--- a/user-processing.test.js
+++ b/user-processing.test.js
@@ -3,7 +3,7 @@ import { getUserValues } from "./user-processing.js";
 
 describe("getUserValues", () => {
 
-    it("seperates values with bars", () => {
+    it("seperates user values with a bar", () => {
         const user = {
             id : 5,
             username : "abc123",
@@ -30,4 +30,34 @@ describe("getUserValues", () => {
 
         expect(result).toEqual("5||bob||012345678");
     })
+
+    it(`outputs user property values in the order id, username, firstName, lastName, studentId
+        regardless of the order of the input`, () => {
+            const user = {
+                lastName : "smith",
+                id : 5,
+                studentId : "012345678",
+                firstName : "bob",
+                username : "abc123"
+            };
+    
+            const result = getUserValues(user);
+    
+            expect(result).toEqual("5|abc123|bob|smith|012345678");
+        })
+
+    it(`outputs user property values in the order id, username, firstName, lastName, studentId
+        regardless of the input order, even if the user values are reversed`, () => {
+            const user = {
+                studentId : "012345678",
+                lastName : "smith",
+                firstName : "bob",
+                username : "abc123",
+                id : 5,
+            };
+    
+            const result = getUserValues(user);
+    
+            expect(result).toEqual("5|abc123|bob|smith|012345678");
+        })
 })


### PR DESCRIPTION
- Changed getUserValues() to always output in the order id, username, firstName, lastName, studentId
- Added two unit tests to check this functionality