### PR TITLE
Add tagging to cdk stack

### DIFF
--- a/lib/__snapshots__/manage-blackboard-users-stack.test.ts.snap
+++ b/lib/__snapshots__/manage-blackboard-users-stack.test.ts.snap
@@ -31,6 +31,44 @@ exports[`ManageBlackboardUsersStack > matches the snapshot 1`] = `
           ],
         },
         "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "york/defined_in",
+            "Value": "cdk",
+          },
+          {
+            "Key": "york/group",
+            "Value": "ESG",
+          },
+          {
+            "Key": "york/name",
+            "Value": "ManageBlackboardUserStack",
+          },
+          {
+            "Key": "york/policy_version",
+            "Value": "2",
+          },
+          {
+            "Key": "york/project",
+            "Value": "ITS-Onboarding-Exercise",
+          },
+          {
+            "Key": "york/pushed_by",
+            "Value": "manual",
+          },
+          {
+            "Key": "york/status",
+            "Value": "dev",
+          },
+          {
+            "Key": "york/team",
+            "Value": "Teaching and Learning",
+          },
+          {
+            "Key": "york/user",
+            "Value": "tr901",
+          },
+        ],
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -60,6 +98,44 @@ exports[`ManageBlackboardUsersStack > matches the snapshot 1`] = `
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
               ],
             ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "york/defined_in",
+            "Value": "cdk",
+          },
+          {
+            "Key": "york/group",
+            "Value": "ESG",
+          },
+          {
+            "Key": "york/name",
+            "Value": "ManageBlackboardUserStack",
+          },
+          {
+            "Key": "york/policy_version",
+            "Value": "2",
+          },
+          {
+            "Key": "york/project",
+            "Value": "ITS-Onboarding-Exercise",
+          },
+          {
+            "Key": "york/pushed_by",
+            "Value": "manual",
+          },
+          {
+            "Key": "york/status",
+            "Value": "dev",
+          },
+          {
+            "Key": "york/team",
+            "Value": "Teaching and Learning",
+          },
+          {
+            "Key": "york/user",
+            "Value": "tr901",
           },
         ],
       },

--- a/lib/manage-blackboard-users-stack.ts
+++ b/lib/manage-blackboard-users-stack.ts
@@ -2,6 +2,7 @@ import * as cdk from "aws-cdk-lib";
 import type { Construct } from "constructs";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
+import { Tags } from "aws-cdk-lib";
 
 export class ManageBlackboardUsersStack extends cdk.Stack {
     constructor(scope: Construct, id: string, properties?: cdk.StackProps) {
@@ -14,5 +15,18 @@ export class ManageBlackboardUsersStack extends cdk.Stack {
             runtime: Runtime.NODEJS_20_X,
             memorySize: 128,
         });
+
+        // Add tags to entire stack and all resources
+        // Required Tags:
+        Tags.of(this).add("york/policy_version", "2");
+        Tags.of(this).add("york/name", "ManageBlackboardUserStack");
+        Tags.of(this).add("york/group", "ESG");
+        Tags.of(this).add("york/project", "ITS-Onboarding-Exercise");
+        Tags.of(this).add("york/status", "dev");
+        Tags.of(this).add("york/pushed_by", "manual");
+        Tags.of(this).add("york/defined_in", "cdk");
+        // Optional Tags:
+        Tags.of(this).add("york/team", "Teaching and Learning");
+        Tags.of(this).add("york/user", "tr901");
     }
 }


### PR DESCRIPTION
- CDK stack is now tagged with the seven required tags and two optional tags (team and user)
- Checked the lambda tags, see below, it all seems to be working
![image](https://github.com/user-attachments/assets/209f7d2d-ad3c-4547-9aa1-00048aea2d07)
![image](https://github.com/user-attachments/assets/aa31865a-5ef0-418a-b65c-a6d8fe6f87d5)
